### PR TITLE
PIP-999: Update payment endpoints to accept amount

### DIFF
--- a/src/HTTP/Request/DeferredPaymentAuth.php
+++ b/src/HTTP/Request/DeferredPaymentAuth.php
@@ -19,6 +19,7 @@
 namespace Afterpay\SDK\HTTP\Request;
 
 use Afterpay\SDK\HTTP\Request;
+use Afterpay\SDK\Model\Money;
 
 class DeferredPaymentAuth extends Request
 {
@@ -35,6 +36,9 @@ class DeferredPaymentAuth extends Request
         'merchantReference' => [
             'type' => 'string',
             'length' => 128
+        ],
+        'amount' => [
+            'type' => Money::class
         ]
     ];
 

--- a/src/HTTP/Request/ImmediatePaymentCapture.php
+++ b/src/HTTP/Request/ImmediatePaymentCapture.php
@@ -19,6 +19,7 @@
 namespace Afterpay\SDK\HTTP\Request;
 
 use Afterpay\SDK\HTTP\Request;
+use Afterpay\SDK\Model\Money;
 
 class ImmediatePaymentCapture extends Request
 {
@@ -32,6 +33,9 @@ class ImmediatePaymentCapture extends Request
         'merchantReference' => [
             'type' => 'string',
             'length' => 128
+        ],
+        'amount' => [
+            'type' => Money::class
         ]
     ];
 


### PR DESCRIPTION
The `amount` property is required for both `ImmediatePaymentCapture` and `DeferredPaymentAuth` if the checkout `mode` is "EXPRESS".

For the "Integrated Shipping" variant of express, the `amount` property is used to verify that there is no discrepancy between the merchant's record of the order total and Afterpay's record of the same. It cannot be used to change the order total.

For the "Deferred Shipping" variant of express, additional fields are required on top of the amount which are not covered in this PR. The `amount` property is required for either variant.

It would be nice to validate this requirement in the SDK. However, presently, there is no higher-level class than the individual Request endpoint classes. In future, we could consider creating, for example, a Checkout class, with a method for converting the checkout into an Order. This could allow the SDK to remember which mode was used in the `CreateCheckoutRequest` class, and use this to determine which validation rules to apply to a subsequent payment request. This would probably need to be implemented in conjunction with a persistent data service on the host, to retain information about checkouts, indexed by token.

In any case, currently, the SDK is not aware of any relationship between the two API calls. It may be simpler and more appropriate in the immediate term to require validation to be implemented outside of the SDK, where there should already be some known configuration to control the checkout mode.