### PR TITLE
PIP-1000: additional fields for deferred shipping

### DIFF
--- a/src/HTTP/Request/DeferredPaymentAuth.php
+++ b/src/HTTP/Request/DeferredPaymentAuth.php
@@ -31,7 +31,8 @@ class DeferredPaymentAuth extends Request
             'type' => 'string'
         ],
         'token' => [
-            'type' => 'string'
+            'type' => 'string',
+            'required' => true
         ],
         'merchantReference' => [
             'type' => 'string',

--- a/src/HTTP/Request/DeferredPaymentAuth.php
+++ b/src/HTTP/Request/DeferredPaymentAuth.php
@@ -19,6 +19,8 @@
 namespace Afterpay\SDK\HTTP\Request;
 
 use Afterpay\SDK\HTTP\Request;
+use Afterpay\SDK\Model\Contact;
+use Afterpay\SDK\Model\Item;
 use Afterpay\SDK\Model\Money;
 
 class DeferredPaymentAuth extends Request
@@ -40,6 +42,18 @@ class DeferredPaymentAuth extends Request
         ],
         'amount' => [
             'type' => Money::class
+        ],
+        'isCheckoutAdjusted' => [
+            'type' => 'boolean'
+        ],
+        'items' => [
+            'type' => Item::class . '[]'
+        ],
+        'shipping' => [
+            'type' => Contact::class
+        ],
+        'paymentScheduleChecksum' => [
+            'type' => 'string'
         ]
     ];
 

--- a/src/HTTP/Request/ImmediatePaymentCapture.php
+++ b/src/HTTP/Request/ImmediatePaymentCapture.php
@@ -19,6 +19,8 @@
 namespace Afterpay\SDK\HTTP\Request;
 
 use Afterpay\SDK\HTTP\Request;
+use Afterpay\SDK\Model\Contact;
+use Afterpay\SDK\Model\Item;
 use Afterpay\SDK\Model\Money;
 
 class ImmediatePaymentCapture extends Request
@@ -37,6 +39,18 @@ class ImmediatePaymentCapture extends Request
         ],
         'amount' => [
             'type' => Money::class
+        ],
+        'isCheckoutAdjusted' => [
+            'type' => 'boolean'
+        ],
+        'items' => [
+            'type' => Item::class . '[]'
+        ],
+        'shipping' => [
+            'type' => Contact::class
+        ],
+        'paymentScheduleChecksum' => [
+            'type' => 'string'
         ]
     ];
 

--- a/src/HTTP/Request/ImmediatePaymentCapture.php
+++ b/src/HTTP/Request/ImmediatePaymentCapture.php
@@ -28,7 +28,8 @@ class ImmediatePaymentCapture extends Request
      */
     protected $data = [
         'token' => [
-            'type' => 'string'
+            'type' => 'string',
+            'required' => true
         ],
         'merchantReference' => [
             'type' => 'string',

--- a/src/Shared/ModelMethods.php
+++ b/src/Shared/ModelMethods.php
@@ -117,6 +117,22 @@ trait ModelMethods
             } elseif ($actualType == 'string' && class_exists($expectedType) && is_array(json_decode($value, true))) {
                 $value = new $expectedType($value);
                 $actualType = get_class($value);
+            } elseif ($actualType == 'string' && $expectedType == 'boolean') {
+                if (in_array(strtolower($value), ['true', '1', 'yes', 'on'])) {
+                    $value = true;
+                    $actualType = gettype($value);
+                } elseif (in_array(strtolower($value), ['false', '0', 'no', 'off'])) {
+                    $value = false;
+                    $actualType = gettype($value);
+                }
+            } elseif ($actualType == 'integer' && $expectedType == 'boolean') {
+                if ($value === 1) {
+                    $value = true;
+                    $actualType = gettype($value);
+                } elseif ($value === 0) {
+                    $value = false;
+                    $actualType = gettype($value);
+                }
             }
         } else {
             $expectedType = $actualType;

--- a/src/Shared/ModelMethods.php
+++ b/src/Shared/ModelMethods.php
@@ -117,20 +117,11 @@ trait ModelMethods
             } elseif ($actualType == 'string' && class_exists($expectedType) && is_array(json_decode($value, true))) {
                 $value = new $expectedType($value);
                 $actualType = get_class($value);
-            } elseif ($actualType == 'string' && $expectedType == 'boolean') {
-                if (in_array(strtolower($value), ['true', '1', 'yes', 'on'])) {
-                    $value = true;
-                    $actualType = gettype($value);
-                } elseif (in_array(strtolower($value), ['false', '0', 'no', 'off'])) {
-                    $value = false;
-                    $actualType = gettype($value);
-                }
-            } elseif ($actualType == 'integer' && $expectedType == 'boolean') {
-                if ($value === 1) {
-                    $value = true;
-                    $actualType = gettype($value);
-                } elseif ($value === 0) {
-                    $value = false;
+            } elseif ($expectedType == 'boolean') {
+                $filteredValue = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+                if (!is_null($filteredValue)) {
+                    $value = $filteredValue;
                     $actualType = gettype($value);
                 }
             }

--- a/test/Unit/HTTP/DeferredPaymentAuthHTTPTest.php
+++ b/test/Unit/HTTP/DeferredPaymentAuthHTTPTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2020-2021 Afterpay Corporate Services Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Afterpay\SDK\Test\Unit\HTTP;
+
+require_once __DIR__ . '/../../autoload.php';
+
+use PHPUnit\Framework\TestCase;
+
+class DeferredPaymentAuthHTTPTest extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testUnexpectedStringForExpectedBooleanException()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(true);
+
+        $request = new \Afterpay\SDK\HTTP\Request\DeferredPaymentAuth();
+
+        try {
+            $request->setIsCheckoutAdjusted('a');
+
+            throw new \Exception('Expected InvalidModelException not thrown');
+        } catch (\Afterpay\SDK\Exception\InvalidModelException $e) {
+            $this->assertEquals('Expected boolean for Afterpay\SDK\HTTP\Request\DeferredPaymentAuth::$isCheckoutAdjusted; string given', $e->getMessage());
+        }
+    }
+
+    public function testBooleanDataTypeAccepted()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\DeferredPaymentAuth();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted(true);
+
+        $this->assertCount(0, $request->getValidationErrors());
+    }
+}

--- a/test/Unit/HTTP/DeferredPaymentAuthHTTPTest.php
+++ b/test/Unit/HTTP/DeferredPaymentAuthHTTPTest.php
@@ -55,4 +55,45 @@ class DeferredPaymentAuthHTTPTest extends TestCase
 
         $this->assertCount(0, $request->getValidationErrors());
     }
+
+    public function testIntegerOneAcceptedForBooleanTrue()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\DeferredPaymentAuth();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted(1);
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertTrue($request->getIsCheckoutAdjusted());
+    }
+
+    public function testIntegerZeroAcceptedForBooleanFalse()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\DeferredPaymentAuth();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted(0);
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertFalse($request->getIsCheckoutAdjusted());
+    }
+
+    public function testIntegerTwoForBooleanException()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(true);
+
+        $request = new \Afterpay\SDK\HTTP\Request\DeferredPaymentAuth();
+
+        try {
+            $request->setIsCheckoutAdjusted(2);
+
+            throw new \Exception('Expected InvalidModelException not thrown');
+        } catch (\Afterpay\SDK\Exception\InvalidModelException $e) {
+            $this->assertEquals('Expected boolean for Afterpay\SDK\HTTP\Request\DeferredPaymentAuth::$isCheckoutAdjusted; integer given', $e->getMessage());
+        }
+    }
 }

--- a/test/Unit/HTTP/DeferredPaymentAuthHTTPTest.php
+++ b/test/Unit/HTTP/DeferredPaymentAuthHTTPTest.php
@@ -96,4 +96,17 @@ class DeferredPaymentAuthHTTPTest extends TestCase
             $this->assertEquals('Expected boolean for Afterpay\SDK\HTTP\Request\DeferredPaymentAuth::$isCheckoutAdjusted; integer given', $e->getMessage());
         }
     }
+
+    public function testEmptyStringAcceptedForBooleanFalse()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\DeferredPaymentAuth();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted('');
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertFalse($request->getIsCheckoutAdjusted());
+    }
 }

--- a/test/Unit/HTTP/ImmediatePaymentCaptureHTTPTest.php
+++ b/test/Unit/HTTP/ImmediatePaymentCaptureHTTPTest.php
@@ -55,4 +55,56 @@ class ImmediatePaymentCaptureHTTPTest extends TestCase
 
         $this->assertCount(0, $request->getValidationErrors());
     }
+
+    public function testStringYesAcceptedForBooleanTrue()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted('Yes');
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertTrue($request->getIsCheckoutAdjusted());
+    }
+
+    public function testStringNoAcceptedForBooleanFalse()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted('No');
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertFalse($request->getIsCheckoutAdjusted());
+    }
+
+    public function testStringTrueAcceptedForBooleanTrue()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted('TRUE');
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertTrue($request->getIsCheckoutAdjusted());
+    }
+
+    public function testStringFalseAcceptedForBooleanFalse()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted('false');
+
+        $this->assertCount(0, $request->getValidationErrors());
+        $this->assertFalse($request->getIsCheckoutAdjusted());
+    }
 }

--- a/test/Unit/HTTP/ImmediatePaymentCaptureHTTPTest.php
+++ b/test/Unit/HTTP/ImmediatePaymentCaptureHTTPTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2020-2021 Afterpay Corporate Services Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Afterpay\SDK\Test\Unit\HTTP;
+
+require_once __DIR__ . '/../../autoload.php';
+
+use PHPUnit\Framework\TestCase;
+
+class ImmediatePaymentCaptureHTTPTest extends TestCase
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function testUnexpectedStringForExpectedBooleanException()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(true);
+
+        $request = new \Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture();
+
+        try {
+            $request->setIsCheckoutAdjusted('a');
+
+            throw new \Exception('Expected InvalidModelException not thrown');
+        } catch (\Afterpay\SDK\Exception\InvalidModelException $e) {
+            $this->assertEquals('Expected boolean for Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture::$isCheckoutAdjusted; string given', $e->getMessage());
+        }
+    }
+
+    public function testBooleanDataTypeAccepted()
+    {
+        \Afterpay\SDK\Model::setAutomaticValidationEnabled(false);
+
+        $request = new \Afterpay\SDK\HTTP\Request\ImmediatePaymentCapture();
+
+        $request->setToken('a');
+        $request->setIsCheckoutAdjusted(true);
+
+        $this->assertCount(0, $request->getValidationErrors());
+    }
+}


### PR DESCRIPTION
- `isCheckoutAdjusted` is a new data type: `boolean`. Validation has been added for any Model or Request that will use this data type. Loose standardisation has been implemented, so `"true"` and `1` are converted to `true` automatically, and `"false"` and `0` are converted to `false`, etc.
- `items` accepts an array of `Item` objects, same as `CreateCheckout`.
- `shipping` accepts a `Contact` object, same as `CreateCheckout`.
- `paymentScheduleChecksum` accepts a string, as returned in JS by the checkout widget.