### PR TITLE
Generate a Merchant Portal URL on Order creation

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -48,6 +48,7 @@ jobs:
         include:
           - php: '5.6'
             mysql: '5.6'
+            run-integration-tests: true
 
           - php: '7.0'
             mysql: '5.7'
@@ -66,6 +67,7 @@ jobs:
 
           - php: '8.0'
             mysql: '8.0'
+            run-integration-tests: true
       fail-fast: false
       max-parallel: 1
 
@@ -131,6 +133,7 @@ jobs:
         run: mysql -h 127.0.0.1 -P ${{ job.services.mysql.ports[ 3306 ] }} -u ${{ secrets.MYSQL_USER }} -p${{ secrets.MYSQL_PASSWORD }} -e "CREATE DATABASE ${{ secrets.MYSQL_DATABASE }};"
 
       - name: Run integration test suite in AU Sandbox
+        if: ${{ matrix.run-integration-tests }}
         env:
           MERCHANT_ID: ${{ secrets.AU_SBOX_MID_1 }}
           SECRET_KEY: ${{ secrets.AU_SBOX_SKEY_1 }}
@@ -146,6 +149,7 @@ jobs:
         run: composer test-integration
 
       - name: Run integration test suite in CA Sandbox
+        if: ${{ matrix.run-integration-tests }}
         env:
           MERCHANT_ID: ${{ secrets.CA_SBOX_MID_1 }}
           SECRET_KEY: ${{ secrets.CA_SBOX_SKEY_1 }}
@@ -161,6 +165,7 @@ jobs:
         run: composer test-integration
 
       - name: Run integration test suite in NZ Sandbox
+        if: ${{ matrix.run-integration-tests }}
         env:
           MERCHANT_ID: ${{ secrets.NZ_SBOX_MID_1 }}
           SECRET_KEY: ${{ secrets.NZ_SBOX_SKEY_1 }}
@@ -176,6 +181,7 @@ jobs:
         run: composer test-integration
 
       - name: Run integration test suite in UK Sandbox
+        if: ${{ matrix.run-integration-tests }}
         env:
           MERCHANT_ID: ${{ secrets.UK_SBOX_MID_1 }}
           SECRET_KEY: ${{ secrets.UK_SBOX_SKEY_1 }}
@@ -191,6 +197,7 @@ jobs:
         run: composer test-integration
 
       - name: Run integration test suite in US Sandbox
+        if: ${{ matrix.run-integration-tests }}
         env:
           MERCHANT_ID: ${{ secrets.US_SBOX_MID_1 }}
           SECRET_KEY: ${{ secrets.US_SBOX_SKEY_1 }}

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "require": {
     },
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3c2a7f098b552cf8d66b14839d08df88",
+    "content-hash": "815332f1da8334453a79ab5ad30b4b4d",
     "packages": [],
     "packages-dev": [
         {

--- a/src/HTTP/Request.php
+++ b/src/HTTP/Request.php
@@ -174,6 +174,32 @@ class Request extends HTTP
     }
 
     /**
+     * Allows the retrieval of getMerchantAccount()->getCountryCode()
+     * from the linked Response class. (self::getMerchantAccount is private.)
+     *
+     * @return string
+     */
+    public function getMerchantAccountCountryCode()
+    {
+        $merchant = $this->getMerchantAccount();
+
+        return $merchant->getCountryCode();
+    }
+
+    /**
+     * Allows the retrieval of getMerchantAccount()->getApiEnvironment()
+     * from the linked Response class. (self::getMerchantAccount is private.)
+     *
+     * @return string
+     */
+    public function getMerchantAccountApiEnvironment()
+    {
+        $merchant = $this->getMerchantAccount();
+
+        return $merchant->getApiEnvironment();
+    }
+
+    /**
      * @param \Afterpay\SDK\MerchantAccount $merchant
      * @return \Afterpay\SDK\HTTP\Request
      * @throws \Afterpay\SDK\Exception\InvalidArgumentException
@@ -596,6 +622,10 @@ class Request extends HTTP
             ->setRawHeaders(implode("\n\n", $response_headers) . "\n\n")
             ->setRawBody(implode("\n\n", $response_parts))
         ;
+
+        if (method_exists($this->response, 'afterReceive')) {
+            $this->response->afterReceive();
+        }
 
         return $this->response->isSuccessful();
     }

--- a/src/HTTP/Response.php
+++ b/src/HTTP/Response.php
@@ -42,6 +42,14 @@ class Response extends HTTP
     }
 
     /**
+     * @return \Afterpay\SDK\HTTP\Request
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
      * @param \Afterpay\SDK\HTTP\Request $request
      * @return \Afterpay\SDK\HTTP\Response
      * @throws \Afterpay\SDK\Exception\InvalidArgumentException

--- a/src/HTTP/Response/DeferredPaymentAuth.php
+++ b/src/HTTP/Response/DeferredPaymentAuth.php
@@ -18,6 +18,7 @@
 
 namespace Afterpay\SDK\HTTP\Response;
 
+use Afterpay\SDK\Helper\UrlHelper;
 use Afterpay\SDK\HTTP\Response;
 
 class DeferredPaymentAuth extends Response
@@ -30,5 +31,34 @@ class DeferredPaymentAuth extends Response
     public function isApproved()
     {
         return $this->isSuccessful() && $this->getParsedBody()->status == 'APPROVED';
+    }
+
+    /**
+     * This method is called immediately after the HTTP response is received.
+     *
+     * Adds a URL for the order view in the merchant portal to the API response.
+     *
+     * WARNING: This method manipulates the raw HTTP response!
+     *
+     * @return \Afterpay\SDK\HTTP\Response\DeferredPaymentAuth
+     */
+    public function afterReceive()
+    {
+        if ($this->isSuccessful()) {
+            $request = $this->getRequest();
+            $bodyObj = $this->getParsedBody();
+
+            if (!is_null($bodyObj)) {
+                $orderId = $bodyObj->id;
+                $countryCode = $request->getMerchantAccountCountryCode();
+                $apiEnvironment = $request->getMerchantAccountApiEnvironment();
+
+                $bodyObj->merchantPortalOrderUrl = UrlHelper::generateMerchantPortalOrderUrl($orderId, $countryCode, $apiEnvironment);
+
+                $this->setRawBody(json_encode($bodyObj, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+            }
+        }
+
+        return $this;
     }
 }

--- a/src/Helper/UrlHelper.php
+++ b/src/Helper/UrlHelper.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2020-2021 Afterpay Corporate Services Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Afterpay\SDK\Helper;
+
+use Afterpay\SDK\Exception\InvalidArgumentException;
+
+final class UrlHelper
+{
+    /**
+     * Generate a Merchant Portal URL for an Order, given its ID, ISO 2-character country code and API environment.
+     *
+     * @param string $orderId
+     * @param string $countryCode
+     * @param string $apiEnvironment
+     * @return string
+     * @throws \Afterpay\SDK\Exception\InvalidArgumentException
+     */
+    public static function generateMerchantPortalOrderUrl($orderId, $countryCode, $apiEnvironment)
+    {
+        if (! is_string($orderId)) {
+            throw new InvalidArgumentException('String expected for $orderId; ' . gettype($orderId) . ' given');
+        }
+
+        if (! is_string($countryCode)) {
+            throw new InvalidArgumentException('String expected for $countryCode; ' . gettype($countryCode) . ' given');
+        }
+
+        if (! is_string($apiEnvironment)) {
+            throw new InvalidArgumentException('String expected for $apiEnvironment; ' . gettype($apiEnvironment) . ' given');
+        }
+
+        $prefix = 'portal.';
+        $tld = 'afterpay.com';
+        $uriCountry = strtolower($countryCode);
+
+        if ($countryCode == 'GB') {
+            $tld = 'clearpay.co.uk';
+            $uriCountry = 'uk';
+        }
+        if (strtolower($apiEnvironment) === 'sandbox') {
+            $prefix .= 'sandbox.';
+        }
+
+        return "https://{$prefix}{$tld}/{$uriCountry}/merchant/order/{$orderId}";
+    }
+}

--- a/test/Integration/GetPaymentByOrderIdIntegrationTest.php
+++ b/test/Integration/GetPaymentByOrderIdIntegrationTest.php
@@ -85,6 +85,9 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
 
         # Call GetPaymentByOrderId using the order ID returned by the API in the previous step.
         # The expectation is that the same Payment object will be returned again.
+        # Note: Since we modified the response for Immediate Payment Capture to include an extra
+        # property, we will need to remove that property before comparing with the Get Payment
+        # response.
 
         $getPaymentByOrderIdRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByOrderId();
 
@@ -94,6 +97,8 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
         ;
 
         $getPaymentByOrderIdResponse = $getPaymentByOrderIdRequest->getResponse();
+
+        unset($immediatePaymentCaptureResponseBody->merchantPortalOrderUrl);
 
         $this->assertEquals(200, $getPaymentByOrderIdResponse->getHttpStatusCode());
         $this->assertEquals($immediatePaymentCaptureResponseBody, $getPaymentByOrderIdResponse->getParsedBody());

--- a/test/Integration/GetPaymentByOrderIdIntegrationTest.php
+++ b/test/Integration/GetPaymentByOrderIdIntegrationTest.php
@@ -76,7 +76,7 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
         ;
 
         $immediatePaymentCaptureResponse = $immediatePaymentCaptureRequest->getResponse();
-
+        $immediatePaymentCaptureResponse->removeEventCreationTimestamps();
         $immediatePaymentCaptureResponseBody = $immediatePaymentCaptureResponse->getParsedBody();
 
         $orderId = $immediatePaymentCaptureResponseBody->id;
@@ -97,6 +97,7 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
         ;
 
         $getPaymentByOrderIdResponse = $getPaymentByOrderIdRequest->getResponse();
+        $getPaymentByOrderIdResponse->removeEventCreationTimestamps();
 
         unset($immediatePaymentCaptureResponseBody->merchantPortalOrderUrl);
 

--- a/test/Integration/GetPaymentByOrderIdIntegrationTest.php
+++ b/test/Integration/GetPaymentByOrderIdIntegrationTest.php
@@ -89,6 +89,11 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
         # property, we will need to remove that property before comparing with the Get Payment
         # response.
 
+        # Note: There is a delay between the order being created and indexed by the search
+        # service. A wait time of 1 second is added to account for this.
+
+        sleep(1);
+
         $getPaymentByOrderIdRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByOrderId();
 
         $getPaymentByOrderIdRequest

--- a/test/Integration/GetPaymentByTokenIntegrationTest.php
+++ b/test/Integration/GetPaymentByTokenIntegrationTest.php
@@ -83,6 +83,9 @@ class GetPaymentByTokenIntegrationTest extends TestCase
 
         # Call GetPaymentByToken using the checkout token returned by the API in Step 1.
         # The expectation is that the same Payment object will be returned again.
+        # Note: Since we modified the response for Immediate Payment Capture to include an extra
+        # property, we will need to remove that property before comparing with the Get Payment
+        # response.
 
         $getPaymentByTokenRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByToken();
 
@@ -92,6 +95,8 @@ class GetPaymentByTokenIntegrationTest extends TestCase
         ;
 
         $getPaymentByTokenResponse = $getPaymentByTokenRequest->getResponse();
+
+        unset($immediatePaymentCaptureResponseBody->merchantPortalOrderUrl);
 
         $this->assertEquals(200, $getPaymentByTokenResponse->getHttpStatusCode());
         $this->assertEquals($immediatePaymentCaptureResponseBody, $getPaymentByTokenResponse->getParsedBody());

--- a/test/Integration/GetPaymentByTokenIntegrationTest.php
+++ b/test/Integration/GetPaymentByTokenIntegrationTest.php
@@ -87,6 +87,11 @@ class GetPaymentByTokenIntegrationTest extends TestCase
         # property, we will need to remove that property before comparing with the Get Payment
         # response.
 
+        # Note: There is a delay between the order being created and indexed by the search
+        # service. A wait time of 1 second is added to account for this.
+
+        sleep(1);
+
         $getPaymentByTokenRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByToken();
 
         $getPaymentByTokenRequest

--- a/test/Integration/GetPaymentByTokenIntegrationTest.php
+++ b/test/Integration/GetPaymentByTokenIntegrationTest.php
@@ -76,7 +76,7 @@ class GetPaymentByTokenIntegrationTest extends TestCase
         ;
 
         $immediatePaymentCaptureResponse = $immediatePaymentCaptureRequest->getResponse();
-
+        $immediatePaymentCaptureResponse->removeEventCreationTimestamps();
         $immediatePaymentCaptureResponseBody = $immediatePaymentCaptureResponse->getParsedBody();
 
         # Step 4 of 4
@@ -95,6 +95,7 @@ class GetPaymentByTokenIntegrationTest extends TestCase
         ;
 
         $getPaymentByTokenResponse = $getPaymentByTokenRequest->getResponse();
+        $getPaymentByTokenResponse->removeEventCreationTimestamps();
 
         unset($immediatePaymentCaptureResponseBody->merchantPortalOrderUrl);
 

--- a/test/Integration/ListPaymentsIntegrationTest.php
+++ b/test/Integration/ListPaymentsIntegrationTest.php
@@ -200,8 +200,6 @@ class ListPaymentsIntegrationTest extends TestCase
             $immediatePaymentCaptureResponseBodies[$i] = $responseBody;
         }
 
-        $toCreatedDate = gmdate('c');
-
         # Step 4 of 4
 
         # Call ListPayments using the timestamps recorded above and a status of "APPROVED".
@@ -212,6 +210,8 @@ class ListPaymentsIntegrationTest extends TestCase
         # service. A wait time of 1 second is added to account for this.
 
         sleep(1);
+
+        $toCreatedDate = gmdate('c');
 
         $listPaymentsRequest = new \Afterpay\SDK\HTTP\Request\ListPayments();
 

--- a/test/Integration/ListPaymentsIntegrationTest.php
+++ b/test/Integration/ListPaymentsIntegrationTest.php
@@ -103,13 +103,13 @@ class ListPaymentsIntegrationTest extends TestCase
         # The expectation is that the same Payment objects will be returned again.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service. A wait time of 1 second is added to account for this.
+        # service. A wait time of 2 seconds is added to account for this.
 
         # Note: Default order is by createdAt descending (newest first), so orders will be
         # returned in the opposite order from what they were created in. The array will
         # therefore be reversed for comparison.
 
-        sleep(1);
+        sleep(2);
 
         $listPaymentsRequest = new \Afterpay\SDK\HTTP\Request\ListPayments();
 

--- a/test/Integration/PingIntegrationTest.php
+++ b/test/Integration/PingIntegrationTest.php
@@ -45,7 +45,7 @@ class PingIntegrationTest extends TestCase
         $pingRequest->send();
 
         $headers_str = $pingRequest->getRawHeaders();
-        $pattern_str = '/^User-Agent: afterpay-sdk-php\/[\d.]+ \(testUserAgentHeader\/1\.0\.0-beta\+exp\.sha\.5114f85; PHP\/[^ ;]+; cURL\/[\d.]+/im';
+        $pattern_str = '/^User-Agent: afterpay-sdk-php\/[\d.]+ \(testUserAgentHeader\/1\.0\.0-beta\+exp\.sha\.5114f85; PHP\/[^;]+; cURL\/[\d.]+/im';
 
         if (method_exists($this, 'assertMatchesRegularExpression')) {
             $this->assertMatchesRegularExpression($pattern_str, $headers_str);

--- a/test/Integration/UpdatePaymentByOrderIdIntegrationTest.php
+++ b/test/Integration/UpdatePaymentByOrderIdIntegrationTest.php
@@ -86,6 +86,9 @@ class UpdatePaymentByOrderIdIntegrationTest extends TestCase
         # Call UpdatePaymentByOrderId using the order ID returned by the API in the previous step.
         # The expectation is that the a second Payment object will be returned, with the only difference
         # being the merchantReference property.
+        # Note: Since we modified the response for Immediate Payment Capture to include an extra
+        # property, we will need to remove that property before comparing with the Update Payment
+        # response.
 
         $updatePaymentByOrderIdRequest = new \Afterpay\SDK\HTTP\Request\UpdatePaymentByOrderId();
 
@@ -105,6 +108,7 @@ class UpdatePaymentByOrderIdIntegrationTest extends TestCase
 
         unset($immediatePaymentCaptureResponseBody->merchantReference);
         unset($updatePaymentByOrderIdResponseBody->merchantReference);
+        unset($immediatePaymentCaptureResponseBody->merchantPortalOrderUrl);
 
         $this->assertEquals($immediatePaymentCaptureResponseBody, $updatePaymentByOrderIdResponseBody);
     }

--- a/test/Integration/UpdateShippingCourierIntegrationTest.php
+++ b/test/Integration/UpdateShippingCourierIntegrationTest.php
@@ -110,6 +110,9 @@ class UpdateShippingCourierIntegrationTest extends TestCase
         # Call UpdateShippingCourier using the order ID returned by the API in the previous step.
         # The expectation is that the a second Payment object will be returned, with the only differences
         # being the properties of the orderDetails.courier object that were altered.
+        # Note: Since we modified the response for Immediate Payment Capture to include an extra
+        # property, we will need to remove that property before comparing with the Update Shipping
+        # Courier response.
 
         $updateShippingCourierRequest = new \Afterpay\SDK\HTTP\Request\UpdateShippingCourier();
 
@@ -134,6 +137,7 @@ class UpdateShippingCourierIntegrationTest extends TestCase
 
         unset($immediatePaymentCaptureResponseBody->orderDetails->courier);
         unset($updateShippingCourierResponseBody->orderDetails->courier);
+        unset($immediatePaymentCaptureResponseBody->merchantPortalOrderUrl);
 
         $this->assertEquals($immediatePaymentCaptureResponseBody, $updateShippingCourierResponseBody);
     }


### PR DESCRIPTION
The JSON response is modified to include a `merchantPortalOrderUrl`
property for the following endpoints:

- Immediate Payment Capture
- Deferred Payment Auth