### PR TITLE
Fix for constructing Payment objects in EU

### DIFF
--- a/src/Model/OrderDetails.php
+++ b/src/Model/OrderDetails.php
@@ -56,6 +56,10 @@ final class OrderDetails extends Model
         ],
         'shippingAmount' => [
             'type' => Money::class
+        ],
+        'purchaseCountry' => [ # For Europe only
+            'type' => 'string',
+            'length' => 2
         ]
     ];
 

--- a/test/Integration/GetPaymentByOrderIdIntegrationTest.php
+++ b/test/Integration/GetPaymentByOrderIdIntegrationTest.php
@@ -90,9 +90,9 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
         # response.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service. A wait time of 1 second is added to account for this.
+        # service in a correct state. A wait time of 30 seconds is added to account for this.
 
-        sleep(1);
+        sleep(30);
 
         $getPaymentByOrderIdRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByOrderId();
 

--- a/test/Integration/GetPaymentByOrderIdIntegrationTest.php
+++ b/test/Integration/GetPaymentByOrderIdIntegrationTest.php
@@ -90,9 +90,9 @@ class GetPaymentByOrderIdIntegrationTest extends TestCase
         # response.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service in a correct state. A wait time of 30 seconds is added to account for this.
+        # service in a correct state. A wait time of 3 seconds is added to account for this.
 
-        sleep(30);
+        sleep(3);
 
         $getPaymentByOrderIdRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByOrderId();
 

--- a/test/Integration/GetPaymentByTokenIntegrationTest.php
+++ b/test/Integration/GetPaymentByTokenIntegrationTest.php
@@ -88,9 +88,9 @@ class GetPaymentByTokenIntegrationTest extends TestCase
         # response.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service. A wait time of 1 second is added to account for this.
+        # service in a correct state. A wait time of 30 seconds is added to account for this.
 
-        sleep(1);
+        sleep(30);
 
         $getPaymentByTokenRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByToken();
 

--- a/test/Integration/GetPaymentByTokenIntegrationTest.php
+++ b/test/Integration/GetPaymentByTokenIntegrationTest.php
@@ -88,9 +88,9 @@ class GetPaymentByTokenIntegrationTest extends TestCase
         # response.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service in a correct state. A wait time of 30 seconds is added to account for this.
+        # service in a correct state. A wait time of 3 seconds is added to account for this.
 
-        sleep(30);
+        sleep(3);
 
         $getPaymentByTokenRequest = new \Afterpay\SDK\HTTP\Request\GetPaymentByToken();
 

--- a/test/Integration/ListPaymentsIntegrationTest.php
+++ b/test/Integration/ListPaymentsIntegrationTest.php
@@ -103,13 +103,13 @@ class ListPaymentsIntegrationTest extends TestCase
         # The expectation is that the same Payment objects will be returned again.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service. A wait time of 2 seconds is added to account for this.
+        # service in a correct state. A wait time of 30 seconds is added to account for this.
 
         # Note: Default order is by createdAt descending (newest first), so orders will be
         # returned in the opposite order from what they were created in. The array will
         # therefore be reversed for comparison.
 
-        sleep(2);
+        sleep(30);
 
         $listPaymentsRequest = new \Afterpay\SDK\HTTP\Request\ListPayments();
 
@@ -207,9 +207,9 @@ class ListPaymentsIntegrationTest extends TestCase
         # will be returned.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service. A wait time of 1 second is added to account for this.
+        # service in a correct state. A wait time of 30 seconds is added to account for this.
 
-        sleep(1);
+        sleep(30);
 
         $toCreatedDate = gmdate('c');
 

--- a/test/Integration/ListPaymentsIntegrationTest.php
+++ b/test/Integration/ListPaymentsIntegrationTest.php
@@ -103,13 +103,13 @@ class ListPaymentsIntegrationTest extends TestCase
         # The expectation is that the same Payment objects will be returned again.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service in a correct state. A wait time of 30 seconds is added to account for this.
+        # service in a correct state. A wait time of 3 seconds is added to account for this.
 
         # Note: Default order is by createdAt descending (newest first), so orders will be
         # returned in the opposite order from what they were created in. The array will
         # therefore be reversed for comparison.
 
-        sleep(30);
+        sleep(3);
 
         $listPaymentsRequest = new \Afterpay\SDK\HTTP\Request\ListPayments();
 
@@ -207,9 +207,9 @@ class ListPaymentsIntegrationTest extends TestCase
         # will be returned.
 
         # Note: There is a delay between the order being created and indexed by the search
-        # service in a correct state. A wait time of 30 seconds is added to account for this.
+        # service in a correct state. A wait time of 3 seconds is added to account for this.
 
-        sleep(30);
+        sleep(3);
 
         $toCreatedDate = gmdate('c');
 


### PR DESCRIPTION
Fix for the following error observed while testing `./sample/HTTPRequestDeferredPaymentVoid.php` with ES credentials:

```html
<b>Fatal error</b>:  Uncaught Exception: Call to undefined method Afterpay\SDK\Model\OrderDetails::setPurchaseCountry in /Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Shared/ModelMethods.php:344
--
  | Stack trace:
  | #0 /Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Shared/ModelMethods.php(256): Afterpay\SDK\Model-&gt;__call('setPurchaseCoun...', Array)
  | #1 /Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Model.php(95): Afterpay\SDK\Model-&gt;passConstructArgsToMagicSetters(Object(stdClass))
  | #2 /Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Shared/ModelMethods.php(82): Afterpay\SDK\Model-&gt;__construct(Object(stdClass))
  | #3 /Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Shared/ModelMethods.php(353): Afterpay\SDK\Model-&gt;setProperty('orderDetails', Object(stdClass))
  | #4 /Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Shared/ModelMethods.php(256): Afterpay\SDK\Model-&gt;__call('se in <b>/Library/WebServer/Documents/sdk/vendor/afterpay-global/afterpay-sdk-php/src/Shared/ModelMethods.php</b> on line <b>344</b>
```