### PR TITLE
EIT-312: Do not bundle tests and sample code with distribution package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,7 @@
 /bin                export-ignore
 /sample             export-ignore
 /test               export-ignore
+/.gitattributes     export-ignore
 /.gitignore         export-ignore
 /composer.json      export-ignore
 /composer.lock      export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+/.github            export-ignore
+/.vscode            export-ignore
+/bin                export-ignore
+/sample             export-ignore
+/test               export-ignore
+/.gitignore         export-ignore
+/composer.json      export-ignore
+/composer.lock      export-ignore
+/CONTRIBUTING.md    export-ignore
+/README.md          export-ignore
+/sample.env.php     export-ignore

--- a/README.md
+++ b/README.md
@@ -20,8 +20,29 @@ Optional recommendations:
 
 Install with [Composer](https://getcomposer.org/).
 
+### For Production
+
+For production usage, ensure the `dist` install method is used. This will exclude development resources
+such as tests and sample code.
+
 ```bash
-composer require afterpay-global/afterpay-sdk-php
+composer require --prefer-dist afterpay-global/afterpay-sdk-php
+```
+
+### For Development
+
+For development purposes, install from source using the `--prefer-source` option. This will include
+development resources such as tests and sample code.
+
+```bash
+composer require --prefer-source afterpay-global/afterpay-sdk-php
+```
+
+Note: If you need to switch between `source` and `dist` installations, you will need to first remove the
+package using the following command, then reinstall using one of the `require` commands above.
+
+```bash
+composer remove afterpay-global/afterpay-sdk-php
 ```
 
 ## Configuration

--- a/composer.json
+++ b/composer.json
@@ -32,20 +32,5 @@
         "test-integration": "./vendor/bin/phpunit --colors=always ./test/Integration",
         "lint": "./vendor/bin/phpcs --standard=PSR12 --error-severity=1 --warning-severity=6 ./src ./test ./sample",
         "lint-autofix": "./vendor/bin/phpcbf --standard=PSR12 --error-severity=1 --warning-severity=6 ./src ./test ./sample; if [ $? -eq 1 ]; then exit 0; fi"
-    },
-    "archive": {
-        "exclude": [
-            "/.github",
-            "/.vscode",
-            "/bin",
-            "/sample",
-            "/test",
-            "/.gitignore",
-            "/composer.json",
-            "/composer.lock",
-            "/CONTRIBUTING.md",
-            "/README.md",
-            "/sample.env.php"
-        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,6 @@
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
     "version": "1.3.4",
-    "require": {
-    },
     "authors": [
         {
             "name": "Afterpay",
@@ -21,6 +19,8 @@
             "Afterpay\\SDK\\Test\\": [ "test" ]
         }
     },
+    "require": {
+    },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.5"
     },
@@ -32,5 +32,20 @@
         "test-integration": "./vendor/bin/phpunit --colors=always ./test/Integration",
         "lint": "./vendor/bin/phpcs --standard=PSR12 --error-severity=1 --warning-severity=6 ./src ./test ./sample",
         "lint-autofix": "./vendor/bin/phpcbf --standard=PSR12 --error-severity=1 --warning-severity=6 ./src ./test ./sample; if [ $? -eq 1 ]; then exit 0; fi"
+    },
+    "archive": {
+        "exclude": [
+            "/.github",
+            "/.vscode",
+            "/bin",
+            "/sample",
+            "/test",
+            "/.gitignore",
+            "/composer.json",
+            "/composer.lock",
+            "/CONTRIBUTING.md",
+            "/README.md",
+            "/sample.env.php"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "require": {
     },
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf15828055343939d00148e729e1a6bc",
+    "content-hash": "2271f6efe0e0082842a0c410850a08c3",
     "packages": [],
     "packages-dev": [
         {

--- a/sample/HTTPRequestCreateRefund.php
+++ b/sample/HTTPRequestCreateRefund.php
@@ -55,7 +55,7 @@ if (! empty($_POST)) {
     }
 } elseif (! empty($_GET)) {
     $immediatePaymentCaptureRequest = new AfterpayImmediatePaymentCaptureRequest([
-        'token' => $_GET['orderToken']
+        'token' => urlencode($_GET['orderToken'])
     ]);
 
     if ($immediatePaymentCaptureRequest->send()) {

--- a/sample/HTTPRequestDeferredPaymentAuth.php
+++ b/sample/HTTPRequestDeferredPaymentAuth.php
@@ -83,7 +83,7 @@ if (! empty($_POST)) {
     }
 } elseif (! empty($_GET)) {
     $deferredPaymentAuthRequest = new AfterpayDeferredPaymentAuthRequest([
-        'token' => $_GET['orderToken']
+        'token' => urlencode($_GET['orderToken'])
     ]);
 
     if (!is_null($merchant)) {

--- a/sample/HTTPRequestDeferredPaymentCapture.php
+++ b/sample/HTTPRequestDeferredPaymentCapture.php
@@ -98,13 +98,13 @@ if (! empty($_POST)) {
             <li>Open to Capture: <?php echo $order->getOpenToCaptureAmount()->getAmount(); ?></li>
             <li>Auth Expiry: <?php echo $order->getEvents()[0]->getExpires(); ?></li>
         </ul>
-        <p><a href="HTTPRequestDeferredPaymentVoid.php?orderId=<?php echo $_GET['orderId'] ?>">Void Payment for this order</a></p>
+        <p><a href="HTTPRequestDeferredPaymentVoid.php?orderId=<?php echo urlencode($_GET['orderId']) ?>">Void Payment for this order</a></p>
         <p><a href="HTTPRequestDeferredPaymentAuth.php">Start again</a></p>
     <?php endif; ?>
     <h3>Deferred Payment Capture</h3>
     <form method="POST">
         <p>Path params:</p>
-        <div>Order ID: <input type="text" name="orderId" value="<?php echo $_GET['orderId'] ?>"></div>
+        <div>Order ID: <input type="text" name="orderId" value="<?php echo urlencode($_GET['orderId']) ?>"></div>
         <p>Body params:</p>
         <div>Request ID: <input type="text" name="requestId" value="<?php echo AfterpayStringHelper::generateUuid(); ?>"></div>
         <div>Amount: <input type="text" name="amount[amount]" value="200.00"></div>

--- a/sample/HTTPRequestDeferredPaymentVoid.php
+++ b/sample/HTTPRequestDeferredPaymentVoid.php
@@ -100,13 +100,13 @@ if (! empty($_POST)) {
             <li>Open to Capture: <?php echo $order->getOpenToCaptureAmount()->toString(); ?></li>
             <li>Auth Expiry: <?php echo $order->getEvents()[0]->getExpires(); ?></li>
         </ul>
-        <p><a href="HTTPRequestDeferredPaymentCapture.php?orderId=<?php echo $_GET['orderId'] ?>">Capture Payment for this order</a></p>
+        <p><a href="HTTPRequestDeferredPaymentCapture.php?orderId=<?php echo urlencode($_GET['orderId']) ?>">Capture Payment for this order</a></p>
         <p><a href="HTTPRequestDeferredPaymentAuth.php">Start again</a></p>
     <?php endif; ?>
     <h3>Deferred Payment Void</h3>
     <form method="POST">
         <p>Path params:</p>
-        <div>Order ID: <input type="text" name="orderId" value="<?php echo $_GET['orderId'] ?>"></div>
+        <div>Order ID: <input type="text" name="orderId" value="<?php echo urlencode($_GET['orderId']) ?>"></div>
         <p>Body params:</p>
         <p><em>Note: Clear the Amount and Currency fields to void the total "Open to Capture" remainder for the order.</em></p>
         <div>Request ID: <input type="text" name="requestId" value="<?php echo AfterpayStringHelper::generateUuid(); ?>"></div>

--- a/sample/HTTPRequestImmediatePaymentCapture.php
+++ b/sample/HTTPRequestImmediatePaymentCapture.php
@@ -58,7 +58,7 @@ if (! empty($_POST)) {
     }
 } elseif (! empty($_GET)) {
     $immediatePaymentCaptureRequest = new AfterpayImmediatePaymentCaptureRequest([
-        'token' => $_GET['orderToken']
+        'token' => urlencode($_GET['orderToken'])
     ]);
 
     if ($immediatePaymentCaptureRequest->send()) {


### PR DESCRIPTION
- Removed tests, sample code and other development files from the `dist` package (and the ZIP archive generated from the GitHub web UI).
- Updated README.md to explain the two different installation options, `--prefer-dist` (default) and `--prefer-source`. See https://getcomposer.org/doc/03-cli.md#require.
- Modified sample code to add escaping of all parameters retrieved from the querystring.