### PR TITLE
EIT-312 restore composer.json for dist package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,8 +5,6 @@
 /test               export-ignore
 /.gitattributes     export-ignore
 /.gitignore         export-ignore
-/composer.json      export-ignore
-/composer.lock      export-ignore
 /CONTRIBUTING.md    export-ignore
 /README.md          export-ignore
 /sample.env.php     export-ignore

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "authors": [
         {
             "name": "Afterpay",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2271f6efe0e0082842a0c410850a08c3",
+    "content-hash": "b6f5f82e547d953bf31a3541754a6f62",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Can't exclude the `composer.json` file from the dist package, as it is used to determine the version for the User-Agent header.

See:

https://github.com/afterpay/sdk-php/blob/7bf6cc558f75c0145a9cacafcfdca376f0f33ab9/src/HTTP/Request.php#L106-L132