### PR TITLE
Bump version again - to release added support for PHP 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "authors": [
         {
             "name": "Afterpay",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a91b1e179f89e7bb38a06bf9aa5d8668",
+    "content-hash": "f2272ba8391e442b74cb91e9a8b6541a",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
Version 1.3.8 is already taken. Restored the branch from #47, bumped the version to 1.3.9 and ran `composer update` again.