### PR TITLE
Non json responses

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.3.9",
+    "version": "1.3.10",
     "authors": [
         {
             "name": "Afterpay",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f2272ba8391e442b74cb91e9a8b6541a",
+    "content-hash": "04ccb54a6dbfe7b481eaf8ce594ae563",
     "packages": [],
     "packages-dev": [
         {

--- a/sample/HTTPRequestPing.php
+++ b/sample/HTTPRequestPing.php
@@ -42,8 +42,7 @@ function tryPing($pingRequest)
         } else {
             # A 3xx, 4xx, or 5xx series HTTP Response.
             # Please log the response code,
-            # errorCode, errorId and message from the body (if available),
-            # or the CF-Ray ID otherwise.
+            # errorCode, errorId and message from the body.
 
             $pingResponse = $pingRequest->getResponse();
             $responseCode = $pingResponse->getHttpStatusCode();
@@ -55,10 +54,6 @@ function tryPing($pingRequest)
                 $message = $body->message;
 
                 echo "ERROR: Received unexpected HTTP {$responseCode} {$contentType} response from Afterpay with errorCode: {$errorCode}; errorId: {$errorId}; message: {$message}\n";
-            } else {
-                $cfRayId = $pingResponse->getParsedHeaders()[ 'cf-ray' ];
-
-                echo "ERROR: Received unexpected HTTP {$responseCode} {$contentType} response from Afterpay with CF-Ray ID: {$cfRayId}\n";
             }
         }
     } catch (AfterpayNetworkException $e) {
@@ -125,7 +120,7 @@ tryPing($pingRequest);
 
 # Expected output (regular expression):
 /*~
-ERROR: Received unexpected HTTP 403 text\/html response from Afterpay with CF-Ray ID: [0-9a-f]{16}-[A-Z]{3}
+ERROR: Received unexpected HTTP 403 text\/html response from Afterpay with errorCode: security_block; errorId: ; message: HTTP request blocked by security service. Cloudflare Ray ID: [0-9a-f]{16}-[A-Z]{3}
 ~*/
 
 

--- a/src/HTTP.php
+++ b/src/HTTP.php
@@ -495,6 +495,17 @@ class HTTP
                 if ($this->isJson() && is_null($this->parsed_body)) {
                     throw new ParsingException(json_last_error_msg(), json_last_error());
                 }
+            } else {
+                // e.g. Blocked by Cloudflare, and received a 403 page instead of a JSON response
+                $response = [
+                    "errorCode" => "security_block",
+                    "errorId" => null,
+                    "message" => "HTTP request blocked by security service. Cloudflare Ray ID: " . $this->getParsedHeaders()['cf-ray']
+                ];
+                if (method_exists($this, 'getHttpStatusCode')) {
+                    $response['httpStatusCode'] = $this->getHttpStatusCode();
+                }
+                $this->parsed_body = (object) $response;
             }
         }
     }

--- a/test/Integration/ListPaymentsIntegrationTest.php
+++ b/test/Integration/ListPaymentsIntegrationTest.php
@@ -142,8 +142,6 @@ class ListPaymentsIntegrationTest extends TestCase
 
         # Create two checkouts, each for 10.00 in the currency of the merchant account.
 
-        $fromCreatedDate = gmdate('c');
-
         $tokens = [];
 
         for ($i = 0; $i <= 1; $i++) {
@@ -211,7 +209,8 @@ class ListPaymentsIntegrationTest extends TestCase
 
         sleep(3);
 
-        $toCreatedDate = gmdate('c');
+        $fromCreatedDate = gmdate('c', strtotime($immediatePaymentCaptureResponseBodies[0]->created) - 1);
+        $toCreatedDate = gmdate('c', strtotime($immediatePaymentCaptureResponseBodies[1]->created) + 1);
 
         $listPaymentsRequest = new \Afterpay\SDK\HTTP\Request\ListPayments();
 


### PR DESCRIPTION
https://apglobal.atlassian.net/browse/EIT-741
Currently the response's parsed body could be NULL, if the response is a html page (e.g. blocked by Cloudflare) instead of a JSON.
This has caused issues in applications (e.g. WooCommerce plugin) that assume the response is in JSON format.
The code change intends to standardize the parsed response body for applications' easier consumption.