### PR TITLE
Migrate to the Afterpay Global API

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -120,6 +120,3 @@ jobs:
           DB_USER: ${{ secrets.MYSQL_USER }}
           DB_PASS: ${{ secrets.MYSQL_PASSWORD }}
         run: composer test-service
-
-      - name: Run network test suite
-        run: composer test-network

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.4.0
+
+_Thu 24 Feb 2022_
+
+- Upgrade to the Afterpay Global API (EIT-782)
+
 ## Version 1.3.10
 
 _Mon 24 Jan 2022_

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ echo $createCheckoutRequest->getRawLog();
 ```
 ########## BEGIN RAW HTTP REQUEST  ##########
 POST /v2/checkouts HTTP/2
-Host: api-sandbox.afterpay.com
+Host: global-api-sandbox.afterpay.com
 Authorization: Basic MzM******************************************************************************************************************************************************************************TA=
 User-Agent: afterpay-sdk-php/0.1.0 (PHP/7.3.11; cURL/7.64.1; Merchant/*****)
 Accept: */*

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ alpha-2 two-character country code of the merchant account. The following method
 2. As the `MERCHANT_ID`, `SECRET_KEY` and `COUNTRY_CODE` environment variables.
 3. By manually defining an object of class `\Afterpay\SDK\MerchantAccount`, passing your account details using its
    `setMerchantId`, `setSecretKey` and `setCountryCode` methods, then passing this object to the the HTTP Request object using
-   its `setMerchantAccount` method. 
+   its `setMerchantAccount` method.
 
 Sample code is provided in the [sample](sample) directory:
 
@@ -249,7 +249,7 @@ echo $createCheckoutRequest->getRawLog();
 POST /v2/checkouts HTTP/2
 Host: global-api-sandbox.afterpay.com
 Authorization: Basic MzM******************************************************************************************************************************************************************************TA=
-User-Agent: afterpay-sdk-php/0.1.0 (PHP/7.3.11; cURL/7.64.1; Merchant/*****)
+User-Agent: afterpay-sdk-php/1.4.0 (PHP/8.1.1; cURL/7.77.0; Merchant/*****)
 Accept: */*
 Content-Type: application/json
 Content-Length: 1223
@@ -257,7 +257,7 @@ Content-Length: 1223
 {"amount":{"amount":"10.00","currency":"AUD"},"consumer":{"phoneNumber":"**** *** ***","givenNames":"****","surname":"****","email":"****************"},"billing":{"name":"*** ********","line1":"***** *","line2":"*** ******* ******","area1":"*********","region":"***","postcode":"****","countryCode":"AU","phoneNumber":"**** *** ***"},"shipping":{"name":"*** ********","line1":"***** *","line2":"*** ******* ******","area1":"*********","region":"***","postcode":"****","countryCode":"AU","phoneNumber":"**** *** ***"},"courier":{"shippedAt":"2019-01-01T00:00:00+10:00","name":"********* ****","tracking":"AA0000000000000","priority":"STANDARD"},"items":[{"name":"******* * **** * **** *","sku":"TSH0001B1MED","quantity":10,"pageUrl":"https:\/\/www.example.com\/page.html","imageUrl":"https:\/\/www.example.com\/image.jpg","price":{"amount":"10.00","currency":"AUD"},"categories":[["Clothing","T-Shirts","Under $25"],["Sale","Clothing"]]}],"discounts":[{"displayName":"20% off SALE","amount":{"amount":"24.00","currency":"AUD"}}],"merchant":{"redirectConfirmUrl":"http:\/\/localhost","redirectCancelUrl":"http:\/\/localhost"},"taxAmount":{"amount":"0.00","currency":"AUD"},"shippingAmount":{"amount":"0.00","currency":"AUD"}}
 ########## END RAW HTTP REQUEST    ##########
 ########## BEGIN RAW HTTP RESPONSE ##########
-HTTP/2 201 
+HTTP/2 201
 date: Tue, 15 Sep 2020 14:20:49 GMT
 content-type: application/json
 content-length: 249

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.3.10",
+    "version": "1.4.0",
     "authors": [
         {
             "name": "Afterpay",

--- a/sample/HTTPRequestGetConfigurationWithPersistence.php
+++ b/sample/HTTPRequestGetConfigurationWithPersistence.php
@@ -77,9 +77,9 @@ object\(stdClass\)#[0-9]+ \(4\) \{
   \["errorCode"\]=>
   string\(12\) "unauthorized"
   \["errorId"\]=>
-  string\(16\) "[0-9a-f]{16}"
+  string\(9\) "cf-worker"
   \["message"\]=>
-  string\(49\) "Credentials are required to access this resource\."
+  string\(55\) "unauthorized - Unable to route request from Cloudflare\."
   \["httpStatusCode"\]=>
   int\(401\)
 \}

--- a/src/HTTP/Request.php
+++ b/src/HTTP/Request.php
@@ -280,6 +280,9 @@ class Request extends HTTP
     }
 
     /**
+     * Note: As of version 1.4.0, the countryCode of the MerchantAccount is not used to construct the API URL, as all regions now use
+     *       the Afterpay Global API. The client implementation is no longer responsible for routing requests to the correct region.
+     *
      * @param string $uri
      * @return \Afterpay\SDK\HTTP\Request
      */
@@ -288,31 +291,12 @@ class Request extends HTTP
         $this->uri = $uri;
 
         $merchant = $this->getMerchantAccount();
-        $countryCode = $merchant->getCountryCode();
         $apiEnvironment = $merchant->getApiEnvironment();
 
-        # Use the Country Code to determine the geographic region
-        # Defaults to Oceania / Asia Pacific (AU/NZ)
-
-        $region_suffix = '';
-        $sandbox_suffix = '-sandbox';
-        $tld = 'afterpay.com';
-
-        if (is_string($countryCode) && strlen($countryCode) == 2) {
-            if (preg_match('/CA|US/', $countryCode)) {
-                $region_suffix = '.us'; # North America
-            } elseif (preg_match('/GB|UK/', $countryCode)) {
-                $region_suffix = '.eu'; # Europe
-            } elseif (preg_match('/ES|FR|IT|PT/', $countryCode)) {
-                $tld = 'clearpay.com'; # Southern Europe
-                $sandbox_suffix = '.sandbox';
-            }
-        }
-
         if (strtolower($apiEnvironment) == 'production') {
-            $this->apiEnvironmentUrl = "https://api{$region_suffix}.{$tld}";
+            $this->apiEnvironmentUrl = "https://global-api.afterpay.com";
         } else {
-            $this->apiEnvironmentUrl = "https://api{$region_suffix}{$sandbox_suffix}.{$tld}";
+            $this->apiEnvironmentUrl = "https://global-api-sandbox.afterpay.com";
         }
 
         curl_setopt($this->ch, CURLOPT_URL, $this->apiEnvironmentUrl . $this->uri);

--- a/src/HTTP/Request.php
+++ b/src/HTTP/Request.php
@@ -36,7 +36,7 @@ class Request extends HTTP
     private $merchant;
 
     /**
-     * @var resource $ch
+     * @var \CurlHandle|resource $ch
      */
     protected $ch;
 

--- a/src/HTTP/Request/Ping.php
+++ b/src/HTTP/Request/Ping.php
@@ -26,6 +26,9 @@ class Ping extends Request
     {
         parent::__construct(... $args);
 
-        $this->setUri('/ping');
+        $this
+            ->setUri('/ping')
+            ->configureBasicAuth()
+        ;
     }
 }

--- a/test/Integration/HTTPIntegrationTest.php
+++ b/test/Integration/HTTPIntegrationTest.php
@@ -32,7 +32,10 @@ class HTTPIntegrationTest extends TestCase
     public function test404()
     {
         $invalidRequest = new \Afterpay\SDK\HTTP\Request();
-        $invalidRequest->setUri('/');
+        $invalidRequest
+            ->setUri('/')
+            ->configureBasicAuth()
+        ;
         $this->assertFalse($invalidRequest->send());
         $this->assertEquals(404, $invalidRequest->getResponse()->getHttpStatusCode());
     }

--- a/test/Network/HTTPNetworkTest.php
+++ b/test/Network/HTTPNetworkTest.php
@@ -45,7 +45,7 @@ class HTTPNetworkTest extends TestCase
             $this->{ method_exists($this, 'assertMatchesRegularExpression') ? 'assertMatchesRegularExpression' : 'assertRegExp' }('/^(7|28)$/', (string) $e->getCode());
 
             if ($e->getCode() == 7) {
-                $this->{ method_exists($this, 'assertMatchesRegularExpression') ? 'assertMatchesRegularExpression' : 'assertRegExp' }('/^Failed to connect to api-sandbox\.afterpay\.com port 443: (Operation|Connection) timed out$/', $e->getMessage());
+                $this->{ method_exists($this, 'assertMatchesRegularExpression') ? 'assertMatchesRegularExpression' : 'assertRegExp' }('/^Failed to connect to global-api-sandbox\.afterpay\.com port 443: (Operation|Connection) timed out$/', $e->getMessage());
             } else {
                 $this->{ method_exists($this, 'assertMatchesRegularExpression') ? 'assertMatchesRegularExpression' : 'assertRegExp' }('/^((Connection|Resolving) timed out after \d+ milliseconds|remaining timeout of \d+ too small to resolve via SIGALRM method|Connection time-out)$/', $e->getMessage());
             }

--- a/test/Unit/HTTPTest.php
+++ b/test/Unit/HTTPTest.php
@@ -82,7 +82,7 @@ class HTTPTest extends TestCase
 
         $pingRequest = new \Afterpay\SDK\HTTP\Request\Ping();
 
-        $this->assertEquals('https://api.afterpay.com', $pingRequest->getApiEnvironmentUrl());
+        $this->assertEquals('https://global-api.afterpay.com', $pingRequest->getApiEnvironmentUrl());
 
         $merchant = new \Afterpay\SDK\MerchantAccount([
             'apiEnvironment' => 'Sandbox'
@@ -92,7 +92,7 @@ class HTTPTest extends TestCase
 
         $pingRequest->setMerchantAccount($merchant);
 
-        $this->assertEquals('https://api-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl()); # The Request will use the apiEnvironment of its MerchantAccount instance
+        $this->assertEquals('https://global-api-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl()); # The Request will use the apiEnvironment of its MerchantAccount instance
         $this->assertEquals('Production', $pingRequest::getApiEnvironment()); # Even though the static property on the parent class hasn't changed
     }
 
@@ -104,7 +104,7 @@ class HTTPTest extends TestCase
 
         $pingRequest = new \Afterpay\SDK\HTTP\Request\Ping();
 
-        $this->assertEquals('https://api.eu-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl());
+        $this->assertEquals('https://global-api-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl());
     }
 
     public function testNaRegionalApiEnvironmentSelection()
@@ -115,7 +115,7 @@ class HTTPTest extends TestCase
 
         $pingRequest = new \Afterpay\SDK\HTTP\Request\Ping();
 
-        $this->assertEquals('https://api.us-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl());
+        $this->assertEquals('https://global-api-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl());
     }
 
     public function testOcRegionalApiEnvironmentSelection()
@@ -126,6 +126,6 @@ class HTTPTest extends TestCase
 
         $pingRequest = new \Afterpay\SDK\HTTP\Request\Ping();
 
-        $this->assertEquals('https://api-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl());
+        $this->assertEquals('https://global-api-sandbox.afterpay.com', $pingRequest->getApiEnvironmentUrl());
     }
 }


### PR DESCRIPTION
The Global API uses the merchant credentials provided in the `Authorization` header to route the request to the appropriate region. This introduces a requirement to authenticate for the Ping endpoint. It also reduces the number of use cases for the `MerchantAccount::$countryCode` property to the following:

- Generation of appropriate mock data for integration tests
- Population of the `purchaseCountry` field of the Create Checkout Request for EU