### PR TITLE
Fix: add empty class for PS upgrade compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 1.4.1
+
+_Fri 06 May 2022_
+
+- Add an empty class for PS upgrade compatibility (INC-1751)
+
 ## Version 1.4.0
 
 _Thu 24 Feb 2022_

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ echo $createCheckoutRequest->getRawLog();
 POST /v2/checkouts HTTP/2
 Host: global-api-sandbox.afterpay.com
 Authorization: Basic MzM******************************************************************************************************************************************************************************TA=
-User-Agent: afterpay-sdk-php/1.4.0 (PHP/8.1.1; cURL/7.77.0; Merchant/*****)
+User-Agent: afterpay-sdk-php/1.4.1 (PHP/8.1.1; cURL/7.77.0; Merchant/*****)
 Accept: */*
 Content-Type: application/json
 Content-Length: 1223

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "afterpay-global/afterpay-sdk-php",
     "license": "Apache-2.0",
     "description": "Official Afterpay SDK for PHP",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "authors": [
         {
             "name": "Afterpay",

--- a/src/HTTP/Response/CreateCheckout.php
+++ b/src/HTTP/Response/CreateCheckout.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (c) 2020-2021 Afterpay Corporate Services Pty Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This file needs to be here to avoid a debris issue
+ * See #apt-im-01124
+ */
+
+namespace Afterpay\SDK\HTTP\Response;
+
+use Afterpay\SDK\HTTP\Response;
+
+class CreateCheckout extends Response
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+}

--- a/src/HTTP/Response/CreateCheckout.php
+++ b/src/HTTP/Response/CreateCheckout.php
@@ -18,7 +18,7 @@
 
 /**
  * This file needs to be here to avoid a debris issue
- * See #apt-im-01124
+ * See INC-1751; #apt-im-01124
  */
 
 namespace Afterpay\SDK\HTTP\Response;


### PR DESCRIPTION
Prestashop does not consistently delete files on module upgrade. 
An empty class was added to address this.