### PR TITLE
Enter a new card if trying to simulate a decline

### DIFF
--- a/test/ConsumerSimulator.php
+++ b/test/ConsumerSimulator.php
@@ -326,11 +326,19 @@ class ConsumerSimulator
         $postheaders = [
             'Content-Type: application/json'
         ];
-        $postbody = json_encode([
+        $data = [
             'cardSecurityCode' => $csc,
-            'traceId' => $this->traceId,
-            'token' => $this->preferredCardToken
-        ]);
+            'traceId' => $this->traceId
+        ];
+        if ($csc === '000') {
+            $data['token'] = $this->preferredCardToken;
+        } else {
+            $data['cardHolderName'] = 'TEST TEST';
+            $data['cardNumber'] = '4111111111111111';
+            $data['cardExpiryMonth'] = '01';
+            $data['cardExpiryYear'] = date('y', strtotime('next year'));
+        }
+        $postbody = json_encode($data);
 
         $responseObj = $this->sendAndLoad($url, $postheaders, $postbody);
 


### PR DESCRIPTION
To fix broken integration tests in AU and NZ identified in #53:

```
> ./vendor/bin/phpunit --colors=always ./test/Integration
PHPUnit 9.5.20 #StandWithUkraine

.F...........F..........                                          24 / 24 (100%)

Time: 03:36.337, Memory: 8.00 MB

There were 2 failures:

1) Afterpay\SDK\Test\Integration\DeferredPaymentAuthIntegrationTest::testDeclined402
Failed asserting that 201 matches expected 402.

/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentAuthIntegrationTest.php:141

2) Afterpay\SDK\Test\Integration\ListPaymentsIntegrationTest::testListPaymentsByStatusArray
Failed asserting that 2 matches expected 1.

/home/runner/work/sdk-php/sdk-php/test/Integration/ListPaymentsIntegrationTest.php:231

FAILURES!
Tests: 24, Assertions: 53, Failures: 2.
```