### PR TITLE
ConsumerSimulator: Don't try to use a preferred card in `setupPurchase` if not given one during `startConsumerCheckout`

### DIFF
--- a/test/ConsumerSimulator.php
+++ b/test/ConsumerSimulator.php
@@ -306,10 +306,10 @@ class ConsumerSimulator
             $this->traceId = $responseObj->responseParsedBody->traceId;
             if (is_object($responseObj->responseParsedBody->preferredCard)) {
                 $this->preferredCardToken = $responseObj->responseParsedBody->preferredCard->token;
+            }
 
-                if ($responseObj->responseHttpStatusCode == 200) {
-                    return;
-                }
+            if ($responseObj->responseHttpStatusCode == 200) {
+                return;
             }
         }
 
@@ -330,7 +330,7 @@ class ConsumerSimulator
             'cardSecurityCode' => $csc,
             'traceId' => $this->traceId
         ];
-        if ($csc === '000') {
+        if ($csc === '000' && !is_null($this->preferredCardToken)) {
             $data['token'] = $this->preferredCardToken;
         } else {
             $data['cardHolderName'] = 'TEST TEST';


### PR DESCRIPTION
This is to fix broken integration tests in UK, where no preferred card is being returned by the Pay API during consumer checkout. Identified in the merge commit [938dc3e](https://github.com/afterpay/sdk-php/commit/938dc3e40c8b71f7e6e86a5576c31d70123a6af5) of #54 here:

https://github.com/afterpay/sdk-php/runs/6421846256?check_suite_focus=true

```
> ./vendor/bin/phpunit --colors=always ./test/Integration
PHPUnit 9.5.20 #StandWithUkraine

EEEEEE...EE.EE......E.EE                                          24 / 24 (100%)

Time: 00:42.697, Memory: 8.00 MB

There were 13 errors:

1) Afterpay\SDK\Test\Integration\DeferredPaymentAuthIntegrationTest::testApproved201
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentAuthIntegrationTest.php:64

2) Afterpay\SDK\Test\Integration\DeferredPaymentAuthIntegrationTest::testDeclined402
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentAuthIntegrationTest.php:125

3) Afterpay\SDK\Test\Integration\DeferredPaymentCaptureIntegrationTest::testCaptureFullAmountSuccess201
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentCaptureIntegrationTest.php:68

4) Afterpay\SDK\Test\Integration\DeferredPaymentCaptureIntegrationTest::testCapturePartialAmountSuccess201
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentCaptureIntegrationTest.php:139

5) Afterpay\SDK\Test\Integration\DeferredPaymentVoidIntegrationTest::testVoidFullAmountSuccess201
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentVoidIntegrationTest.php:68

6) Afterpay\SDK\Test\Integration\DeferredPaymentVoidIntegrationTest::testVoidPartialAmountSuccess201
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/DeferredPaymentVoidIntegrationTest.php:137

7) Afterpay\SDK\Test\Integration\GetPaymentByOrderIdIntegrationTest::testOk200
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/GetPaymentByOrderIdIntegrationTest.php:65

8) Afterpay\SDK\Test\Integration\GetPaymentByTokenIntegrationTest::testOk200
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/GetPaymentByTokenIntegrationTest.php:65

9) Afterpay\SDK\Test\Integration\ListPaymentsIntegrationTest::testListPaymentsByTokenArray
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/ListPaymentsIntegrationTest.php:70

10) Afterpay\SDK\Test\Integration\ListPaymentsIntegrationTest::testListPaymentsByStatusArray
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/ListPaymentsIntegrationTest.php:[167](https://github.com/afterpay/sdk-php/runs/6421846256?check_suite_focus=true#step:3:167)

11) Afterpay\SDK\Test\Integration\ReversePaymentByTokenIntegrationTest::testNoContent204
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/ReversePaymentByTokenIntegrationTest.php:65

12) Afterpay\SDK\Test\Integration\UpdatePaymentByOrderIdIntegrationTest::testOk200
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/UpdatePaymentByOrderIdIntegrationTest.php:66

13) Afterpay\SDK\Test\Integration\UpdateShippingCourierIntegrationTest::testOk200
Exception: startConsumerCheckout did not complete as expected

/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:316
/home/runner/work/sdk-php/sdk-php/test/ConsumerSimulator.php:448
/home/runner/work/sdk-php/sdk-php/test/Integration/UpdateShippingCourierIntegrationTest.php:72

ERRORS!
Tests: 24, Assertions: 17, Errors: 13.
```