### PR TITLE
Add shippingOptionIdentifier prop to CreateCheckout

### DIFF
--- a/src/HTTP/Request/CreateCheckout.php
+++ b/src/HTTP/Request/CreateCheckout.php
@@ -86,6 +86,9 @@ class CreateCheckout extends Request
         'purchaseCountry' => [
             'type' => 'string',
             'length' => 2
+        ],
+        'shippingOptionIdentifier' => [
+            'type' => 'string'
         ]
     ];
 


### PR DESCRIPTION
Adding ability to preselect a shipping method when using Express checkout and integrated shipping.

Requires the `shippingOptionIdentifier` property to be passed in when creating the checkout. If this string matches an identifier that is returned in one of the shipping options in the `onShippingAddressChange` callback, it will be preselected