### PR TITLE
Fix for 500 errors on DECLINED order tests for US Sandbox

### DIFF
--- a/src/MerchantAccount.php
+++ b/src/MerchantAccount.php
@@ -91,7 +91,7 @@ final class MerchantAccount
                 $data[ 'line1' ] = '222 Kearny Street';
                 $data[ 'area1' ] = 'San Francisco';
                 $data[ 'region' ] = 'CA';
-                $data[ 'postcode' ] = '94108-4509';
+                $data[ 'postcode' ] = '94108';
                 break;
 
             case 'AU':

--- a/test/ConsumerSimulator.php
+++ b/test/ConsumerSimulator.php
@@ -21,6 +21,7 @@ namespace Afterpay\SDK\Test;
 use Afterpay\SDK\Config;
 use Afterpay\SDK\MerchantAccount;
 use Afterpay\SDK\HTTP;
+use Afterpay\SDK\Helper\ArrayHelper;
 
 class ConsumerSimulator
 {
@@ -341,11 +342,11 @@ class ConsumerSimulator
             $countryCode = HTTP::getCountryCode();
             $mockData = MerchantAccount::generateMockData($countryCode);
             $data['address'] = [
-                'city' => $mockData['area1'],
+                'city' => ArrayHelper::maybeGet('area1', $mockData),
                 'country' => $countryCode,
-                'postcode' => $mockData['postcode'],
-                'state' => $mockData['region'],
-                'street1' => $mockData['line1']
+                'postcode' => ArrayHelper::maybeGet('postcode', $mockData),
+                'state' => ArrayHelper::maybeGet('region', $mockData),
+                'street1' => ArrayHelper::maybeGet('line1', $mockData)
             ];
         }
         $postbody = json_encode($data);

--- a/test/ConsumerSimulator.php
+++ b/test/ConsumerSimulator.php
@@ -19,6 +19,7 @@
 namespace Afterpay\SDK\Test;
 
 use Afterpay\SDK\Config;
+use Afterpay\SDK\MerchantAccount;
 use Afterpay\SDK\HTTP;
 
 class ConsumerSimulator
@@ -337,6 +338,15 @@ class ConsumerSimulator
             $data['cardNumber'] = '4000000000009979';
             $data['cardExpiryMonth'] = '01';
             $data['cardExpiryYear'] = date('y', strtotime('next year'));
+            $countryCode = HTTP::getCountryCode();
+            $mockData = MerchantAccount::generateMockData($countryCode);
+            $data['address'] = [
+                'city' => $mockData['area1'],
+                'country' => $countryCode,
+                'postcode' => $mockData['postcode'],
+                'state' => $mockData['region'],
+                'street1' => $mockData['line1']
+            ];
         }
         $postbody = json_encode($data);
 


### PR DESCRIPTION
- Send a billing address to topaz when simulating a decline in integration tests