### PR TITLE
Prevent cookie props from overwriting existing query params.

### DIFF
--- a/src/HTTP/Response/CreateCheckout.php
+++ b/src/HTTP/Response/CreateCheckout.php
@@ -57,14 +57,18 @@ class CreateCheckout extends Response
                         $cookieObj = json_decode($decodedCookie, false);
                         $urlChanged = false;
 
-                        if (isset($cookieObj->deviceId) && preg_match('/^[0-9a-z-]*$/i', $cookieObj->deviceId)) {
+                        $query_str = parse_url($bodyObj->redirectCheckoutUrl, PHP_URL_QUERY);
+                        $query_arr = array();
+                        parse_str($query_str, $query_arr);
+
+                        if (isset($cookieObj->deviceId) && !array_key_exists('device_id', $query_arr) && preg_match('/^[0-9a-z-]*$/i', $cookieObj->deviceId)) {
                             $bodyObj->redirectCheckoutUrl .= "&device_id={$cookieObj->deviceId}";
                             $urlChanged = true;
                         }
 
                         if (isset($cookieObj->checkout) && is_object($cookieObj->checkout)) {
                             foreach ($cookieObj->checkout as $prop => $val) {
-                                if (preg_match('/^[0-9a-z]+$/i', $prop) && preg_match('/^[0-9a-z-]*$/i', $val)) {
+                                if (!array_key_exists($prop, $query_arr) && preg_match('/^[0-9a-z]+$/i', $prop) && preg_match('/^[0-9a-z-]*$/i', $val)) {
                                     $bodyObj->redirectCheckoutUrl .= "&{$prop}={$val}";
                                     $urlChanged = true;
                                 }


### PR DESCRIPTION
Follows #70 for EIT-3646.

Accepts @abbadata's suggestion to prevent the `token` param from being overwritten by the cookie.

Tested with this cookie on localhost:

```json
{"deviceId":"23f15075-817f-48d0-be3e-8f865ccf9ffc","userId":"","eventId":38,"lastEventTime":1701830793034,"checkout":{"token":"another-token","abc":"def"}}
```

Result (excerpt) from `/sample/HTTPRequestCreateCheckoutWithValidation.php`:

```json
{
    "token": "001.agkokl6f6t7cpic9ccs89mad6r64u58330vi6v09884is94m",
    "expires": "2024-01-19T04:47:59.056Z",
    "redirectCheckoutUrl": "https://portal.sandbox.afterpay.com/au/checkout/?token=001.agkokl6f6t7cpic9ccs89mad6r64u58330vi6v09884is94m&device_id=23f15075-817f-48d0-be3e-8f865ccf9ffc&abc=def"
}
```